### PR TITLE
Add file_not_exists_ok parameter

### DIFF
--- a/byoconfig/config.pyi
+++ b/byoconfig/config.pyi
@@ -20,6 +20,7 @@ class Config(EnvVariableSource, FileVariableSource, SecretsManagerVariableSource
         env_trim_prefix: bool = True,
         file_path: Optional[str] = None,
         file_forced_type: Optional[FileTypes] = None,
+        file_not_exists_ok: Optional[bool] = False,
         aws_secret_name: Optional[str] = "",
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
@@ -74,6 +75,10 @@ class Config(EnvVariableSource, FileVariableSource, SecretsManagerVariableSource
 
             file_forced_type (FileTypes: ['YAML', 'JSON', 'TOML'] ):
                 The file type of the source file, if you don't want to use the file's extension.
+
+            file_not_exists_ok (Optional[bool]):
+                If False, an exception will be raised if the file at `file_path` does not exist.
+                If True, the configuration will continue as normal if the file at `file_path` does not exist.
 
             aws_secret_name (str):
                 The name of the secret stored in AWS Secrets Manager.

--- a/byoconfig/singleton.py
+++ b/byoconfig/singleton.py
@@ -10,7 +10,6 @@ def singleton__new__method(_kls) -> Callable[..., Any]:
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
             with _singleton_lock:
-                # Double-check pattern
                 if cls._instance is None:
                     cls._instance = super(_kls, cls).__new__(cls)
         return cls._instance

--- a/byoconfig/sources/file.py
+++ b/byoconfig/sources/file.py
@@ -68,12 +68,17 @@ class FileVariableSource(BaseVariableSource):
             # Blindly cast into a list, JSON and TOML don't support tuples or sets
             tuple: self.convert_dumped_configuration_data,
             set: self.convert_dumped_configuration_data,
-            # Recurse
+            # Recurse, ensuring types are cast throughout the data structure
             list: self.convert_dumped_configuration_data,
             dict: self.convert_dumped_configuration_data,
         }
 
-    def load_from_file(self, path: str = None, forced_type: FileTypes = None):
+    def load_from_file(
+        self,
+        path: str = None,
+        forced_type: FileTypes = None,
+        not_exists_ok: bool = False,
+    ):
         if not path:
             return
         try:
@@ -83,6 +88,10 @@ class FileVariableSource(BaseVariableSource):
                 f"An exception occurred while loading file '{str(path)}': {e.args}",
                 self,
             )
+
+        if not path.exists() and not_exists_ok:
+            return
+
         if not path.exists():
             raise FileNotFoundError(f"Config file {str(path)} does not exist")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "byoconfig"
-version = "1.2.1"
+version = "1.2.2"
 description = "A configuration class that supports plugins, multiple file formats, heirarchical configuration, and more."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from json import loads as json_load
 from mocks.mock_secrets_manager_client import MockSecretsManagerClient
 from unittest.mock import patch
 
+import pytest
 from yaml import safe_load as yaml_load
 from toml import load as toml_load
 
@@ -478,3 +479,12 @@ def test_dumping_excluded_attrs():
             assert "class_var_that_gets_value_later_excluded" not in dumped_config
             assert "class_var_added_via_init_excluded" not in dumped_config
             assert "class_var_added_via_init_included" in dumped_config
+
+
+def test_non_existent_file_path_arg():
+    # Exception not raised
+    Config(file_path="a_path_that_doesnt_exist.yml", file_not_exists_ok=True)
+    # Exception raised
+    with pytest.raises(FileNotFoundError):
+        # With default file_not_exists_ok=False
+        Config(file_path="a_path_that_doesnt_exist.yml")


### PR DESCRIPTION
Add `not_exists_ok` parameter to `FileVariableSource.__init__`:
  - Allows users to pass non-existent files for the `file_path` parameter, given that they provide the `file_not_exists_ok=True` parameter to `Config.__init__`.
  - Updated `config.pyi` to reflect signature change.

